### PR TITLE
Fix greek translations

### DIFF
--- a/lib/languages.dart
+++ b/lib/languages.dart
@@ -282,7 +282,7 @@ Map<String, List<String>> mainTranslate = {
     '晴朗的夜晚',
     '快晴の夜',
     'Bezchmurna noc',
-    'Καθαρή Βραδυά'
+    'Καθαρή Βραδιά'
   ],
   'Partly Cloudy': [
     'Partly Cloudy',
@@ -605,7 +605,7 @@ Map<String, List<String>> mainTranslate = {
     '空气质量',
     '空気の質',
     'jakość powietrza',
-    'ποιότητα αέρος'
+    'ποιότητα αέρα'
   ],
 
   'good': [
@@ -620,7 +620,7 @@ Map<String, List<String>> mainTranslate = {
     '好',
     '良い',
     'dobry',
-    'καλός'
+    'Εξαιρετική'
   ],
   'fair': [
     'fair',
@@ -634,7 +634,7 @@ Map<String, List<String>> mainTranslate = {
     '公平',
     '公平',
     'dopuszczalny',
-    'δίκαιος'
+    'καλή'
   ],
   'moderate': [
     'moderate',
@@ -648,7 +648,7 @@ Map<String, List<String>> mainTranslate = {
     '适中',
     '適度',
     'umiarkowany',
-    'μέτριος'
+    'ασθενής'
   ],
   'poor': [
     'poor',
@@ -662,7 +662,7 @@ Map<String, List<String>> mainTranslate = {
     '较差',
     '悪い',
     'słaby',
-    'κακός'
+    'ανθυγιεινή'
   ],
   'very poor': [
     'very poor',
@@ -676,7 +676,7 @@ Map<String, List<String>> mainTranslate = {
     '非常差',
     '非常に悪い',
     'bardzo słaby',
-    'πολύ κακός'
+    'πολύ ανθυγιεινή'
   ],
   'unhealthy': [
     'unhealthy',
@@ -690,7 +690,7 @@ Map<String, List<String>> mainTranslate = {
     '不健康',
     '不健康',
     'niezdrowy',
-    'ανθυγιεινός'
+    'επικίνδυνη'
   ],
 
   'precipitation': [
@@ -1555,7 +1555,7 @@ Map<String, List<String>> mainTranslate = {
     '主要污染物',
     '主要汚染物質',
     'główny zanieczyszczający',
-    'κύριος ρύπος'
+    'κύριο ρυπογόνο'
   ],
   "Alder Pollen": [
     'Alder Pollen',
@@ -1653,7 +1653,7 @@ Map<String, List<String>> mainTranslate = {
     '每日空气质量指数',
     '毎日のAQI',
     'dzienne AQI',
-    'καθημερινό AQI'
+    'καθημερινός AQI'
   ],
 
   "Date format": [

--- a/lib/languages.dart
+++ b/lib/languages.dart
@@ -620,7 +620,7 @@ Map<String, List<String>> mainTranslate = {
     '好',
     '良い',
     'dobry',
-    'Εξαιρετική'
+    'εξαιρετική'
   ],
   'fair': [
     'fair',


### PR DESCRIPTION
I corrected a few typos and the general feeling of the translations. For example for the air quality I use the proper gender for the words, and I also used the scale used by [accuweather](https://www.accuweather.com/el/gr/athens/182536/air-quality-index/182536) for improved clarity .
