### PR TITLE
put a fancier word to avoid newline

### DIFF
--- a/lib/languages.dart
+++ b/lib/languages.dart
@@ -114,7 +114,7 @@ Map<String, List<String>> mainTranslate = {
     '降水',
     '降水量',
     'Opady',
-    'Βροχόπτωση'
+    'Υετός'
   ],
   'Settings': [
     'Settings',


### PR DESCRIPTION
Sorry for the new MR right when you merged the previous one but I also changed "Βροχόπτωση" to a fancier equivalent (Υετός) because the current one is split to a newline and the result is [annoying](https://imgur.com/a/OuQw06I).