### PR TITLE
fix #214: Hourly forecast widget now respects 12-hour clock setting

### DIFF
--- a/android/app/src/main/kotlin/com/marotidev/overmorrow/widgets/OneHourlyWidget.kt
+++ b/android/app/src/main/kotlin/com/marotidev/overmorrow/widgets/OneHourlyWidget.kt
@@ -39,6 +39,8 @@ import es.antonborri.home_widget.actionStartActivity
 import com.marotidev.overmorrow.services.getBackColor
 import com.marotidev.overmorrow.services.getFrontColor
 import com.marotidev.overmorrow.services.getIconForCondition
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class OneHourlyWidget : GlanceAppWidget() {
 
@@ -72,6 +74,8 @@ class OneHourlyWidget : GlanceAppWidget() {
 
         val backColor = getBackColor(backColorString)
         val frontColor = getFrontColor(frontColorString)
+
+        val timeMode = prefs.getString("Time mode", "12 hour") ?: "12 hour"
 
         val tempList: List<Int> = try {
             hourlyTempList.let { gson.fromJson(it, hourlyTempType) } ?: emptyList()
@@ -189,7 +193,7 @@ class OneHourlyWidget : GlanceAppWidget() {
                                 .size(28.dp, 28.dp)
                         )
                         Text(
-                            text = item,
+                            text = formatHourLabel(item, timeMode),
                             style = TextStyle(
                                 color = GlanceTheme.colors.outline,
                                 fontSize = 14.sp,
@@ -203,5 +207,21 @@ class OneHourlyWidget : GlanceAppWidget() {
 
         }
 
+    }
+}
+
+private fun formatHourLabel(rawLabel: String, timeMode: String): String {
+    val hourStr = rawLabel.removeSuffix("h")
+    val hour = hourStr.toIntOrNull() ?: return rawLabel
+    return if (timeMode == "12 hour") {
+        val amPm = if (hour < 12) "am" else "pm"
+        val hour12 = when {
+            hour == 0 -> 12
+            hour > 12 -> hour - 12
+            else -> hour
+        }
+        "$hour12$amPm"
+    } else {
+        "${hour}h"
     }
 }

--- a/android/app/src/main/kotlin/com/marotidev/overmorrow/widgets/OneHourlyWidget.kt
+++ b/android/app/src/main/kotlin/com/marotidev/overmorrow/widgets/OneHourlyWidget.kt
@@ -39,8 +39,6 @@ import es.antonborri.home_widget.actionStartActivity
 import com.marotidev.overmorrow.services.getBackColor
 import com.marotidev.overmorrow.services.getFrontColor
 import com.marotidev.overmorrow.services.getIconForCondition
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 class OneHourlyWidget : GlanceAppWidget() {
 
@@ -74,8 +72,6 @@ class OneHourlyWidget : GlanceAppWidget() {
 
         val backColor = getBackColor(backColorString)
         val frontColor = getFrontColor(frontColorString)
-
-        val timeMode = prefs.getString("Time mode", "12 hour") ?: "12 hour"
 
         val tempList: List<Int> = try {
             hourlyTempList.let { gson.fromJson(it, hourlyTempType) } ?: emptyList()
@@ -193,7 +189,7 @@ class OneHourlyWidget : GlanceAppWidget() {
                                 .size(28.dp, 28.dp)
                         )
                         Text(
-                            text = formatHourLabel(item, timeMode),
+                            text = item,
                             style = TextStyle(
                                 color = GlanceTheme.colors.outline,
                                 fontSize = 14.sp,
@@ -207,21 +203,5 @@ class OneHourlyWidget : GlanceAppWidget() {
 
         }
 
-    }
-}
-
-private fun formatHourLabel(rawLabel: String, timeMode: String): String {
-    val hourStr = rawLabel.removeSuffix("h")
-    val hour = hourStr.toIntOrNull() ?: return rawLabel
-    return if (timeMode == "12 hour") {
-        val amPm = if (hour < 12) "am" else "pm"
-        val hour12 = when {
-            hour == 0 -> 12
-            hour > 12 -> hour - 12
-            else -> hour
-        }
-        "$hour12$amPm"
-    } else {
-        "${hour}h"
     }
 }

--- a/lib/decoders/decode_OM.dart
+++ b/lib/decoders/decode_OM.dart
@@ -22,6 +22,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/caching_service.dart';
@@ -790,6 +791,7 @@ Future<LightHourlyForecastData> omGetHourlyForecast(placeName, lat, lon, SharedP
   List<String> hourly1Names = [];
 
   final String tempUnit = prefs.getString("Temperature") ?? "˚C";
+  final String timeMode = prefs.getString("Time mode") ?? "12 hour";
 
   for (int i = 0; i < item["hourly"]["temperature_2m"].length; i++) {
     DateTime there = DateTime.parse(item["hourly"]["time"][i]);
@@ -797,13 +799,13 @@ Future<LightHourlyForecastData> omGetHourlyForecast(placeName, lat, lon, SharedP
     if (d.hour % 6 == 0) {
       hourly6Conditions.add(oMCurrentTextCorrection(item["hourly"]["weather_code"][i], sunStatus, there));
       hourly6Temps.add(unitConversion(item["hourly"]["temperature_2m"][i],tempUnit).round());
-      hourly6Names.add("${d.hour}h");
+      hourly6Names.add(formatHourByTimeMode(d, timeMode));
     }
 
     if (d.difference(now).inHours >= 0 && d.difference(now).inHours < 3) {
       hourly1Conditions.add(oMCurrentTextCorrection(item["hourly"]["weather_code"][i], sunStatus, there));
       hourly1Temps.add(unitConversion(item["hourly"]["temperature_2m"][i],tempUnit).round());
-      hourly1Names.add("${d.hour}h");
+      hourly1Names.add(formatHourByTimeMode(d, timeMode));
     }
   }
 

--- a/lib/decoders/decode_mn.dart
+++ b/lib/decoders/decode_mn.dart
@@ -20,6 +20,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 import 'package:overmorrow/decoders/decode_OM.dart';
 import 'package:overmorrow/services/weather_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -470,6 +471,7 @@ Future<LightHourlyForecastData> metNGetLightHourlyData(placeName, lat, lon, Shar
   DateTime now = DateTime.now();
 
   final String tempUnit = prefs.getString("Temperature") ?? "˚C";
+  final String timeMode = prefs.getString("Time mode") ?? "12 hour";
 
   for (int i = 0; i < min(item["properties"]["timeseries"].length, 23); i++) {
     final hour = item["properties"]["timeseries"][i];
@@ -481,7 +483,7 @@ Future<LightHourlyForecastData> metNGetLightHourlyData(placeName, lat, lon, Shar
           hour["data"]["next_1_hours"]["summary"]["symbol_code"]));
       hourly6Temps.add(unitConversion(
           hour["data"]["instant"]["details"]["air_temperature"],tempUnit).round(),);
-      hourly6Names.add("${d.hour}h");
+      hourly6Names.add(formatHourByTimeMode(d, timeMode));
     }
 
     if (i < 4) {
@@ -489,7 +491,7 @@ Future<LightHourlyForecastData> metNGetLightHourlyData(placeName, lat, lon, Shar
           hour["data"]["next_1_hours"]["summary"]["symbol_code"]));
       hourly1Temps.add(unitConversion(
           hour["data"]["instant"]["details"]["air_temperature"],tempUnit).round(),);
-      hourly1Names.add("${d.hour}h");
+      hourly1Names.add(formatHourByTimeMode(d, timeMode));
     }
   }
 

--- a/lib/decoders/decode_wapi.dart
+++ b/lib/decoders/decode_wapi.dart
@@ -487,6 +487,7 @@ Future<LightHourlyForecastData> wapiGetLightHourlyData(placeName, lat, lon, Shar
   DateTime now = DateTime.now();
 
   final String tempUnit = prefs.getString("Temperature") ?? "˚C";
+  final String timeMode = prefs.getString("Time mode") ?? "12 hour";
 
   for (int i = 0; i < item["forecast"]["forecastday"][0]["hour"].length; i++) {
     final hour = item["forecast"]["forecastday"][0]["hour"][i];
@@ -496,13 +497,13 @@ Future<LightHourlyForecastData> wapiGetLightHourlyData(placeName, lat, lon, Shar
     if (d.hour % 6 == 0) {
       hourly6Conditions.add(wapiTextCorrection(hour["condition"]["code"], hour["is_day"]));
       hourly6Temps.add(unitConversion(hour["temp_c"], tempUnit).round());
-      hourly6Names.add("${d.hour}h");
+      hourly6Names.add(formatHourByTimeMode(d, timeMode));
     }
 
     if (d.difference(now).inHours >= 0 && d.difference(now).inHours < 3) {
       hourly1Conditions.add(wapiTextCorrection(hour["condition"]["code"], hour["is_day"]));
       hourly1Temps.add(unitConversion(hour["temp_c"], tempUnit).round());
-      hourly1Names.add("${d.hour}h");
+      hourly1Names.add(formatHourByTimeMode(d, timeMode));
     }
   }
 

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -16,11 +16,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
+import 'package:flutter/material.dart';
 import 'package:overmorrow/services/notification_service.dart';
 import 'package:overmorrow/services/widget_service.dart';
 import 'package:overmorrow/weather_refact.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter/material.dart';
 
 import 'color_service.dart';
 
@@ -375,7 +375,7 @@ class SettingsProvider with ChangeNotifier {
     PreferenceUtils.setString("Time mode", to);
     _timeMode = to;
     notifyListeners();
-    WidgetService.saveData("Time mode", to).then((_) => WidgetService.reloadWidgets());
+    WidgetService.updateWidgetTimeFormat(to).then((_) => WidgetService.reloadWidgets());
   }
 
   void setDateFormat(String to) {

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import 'package:overmorrow/services/notification_service.dart';
+import 'package:overmorrow/services/widget_service.dart';
 import 'package:overmorrow/weather_refact.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
@@ -374,6 +375,7 @@ class SettingsProvider with ChangeNotifier {
     PreferenceUtils.setString("Time mode", to);
     _timeMode = to;
     notifyListeners();
+    WidgetService.saveData("Time mode", to).then((_) => WidgetService.reloadWidgets());
   }
 
   void setDateFormat(String to) {

--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -69,6 +69,13 @@ String convertToShortTime(DateTime time, BuildContext context) {
   return DateFormat('H:mm').format(time);
 }
 
+String formatHourByTimeMode(DateTime time, String timeMode) {
+  if (timeMode == "12 hour") {
+    return DateFormat('ha').format(time).toLowerCase();
+  }
+  return "${time.hour}h";
+}
+
 String convertToWeekDayTime(DateTime? time, context) {
   if (time != null) {
     String weekName = getWeekName(time.weekday - 1, context);
@@ -126,6 +133,7 @@ num unitConversion(double value, String unit, {decimals = 2}) {
   }
   return double.parse(a.toStringAsFixed(decimals));
 }
+
 
 String aqiDescLocalization(index, localizations) {
   return [

--- a/lib/services/widget_service.dart
+++ b/lib/services/widget_service.dart
@@ -16,14 +16,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:home_widget/home_widget.dart';
+import 'package:intl/intl.dart';
 import 'package:overmorrow/services/notification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
 import '../decoders/weather_data.dart';
 import '../main_ui.dart';
+import 'weather_service.dart';
 
 const updateWeatherDataKey = "com.marotidev.overmorrow.updateWeatherData";
 
@@ -114,6 +117,35 @@ class WidgetService {
 
   static Future<void> saveBackgroundTaskState(String state) async {
     await saveData("widget.backgroundUpdateState", state);
+  }
+
+  static int _getHourFromLabel(String label) {
+    if (label.endsWith('h')) {
+      return int.tryParse(label.substring(0, label.length - 1)) ?? 0;
+    }
+    try {
+      return DateFormat('ha').parse(label.toUpperCase()).hour;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  static Future<void> updateWidgetTimeFormat(String timeMode) async {
+    final installedWidgets = await HomeWidget.getInstalledWidgets();
+    for (final widgetInfo in installedWidgets.where((w) =>
+        w.androidClassName == forecastWidgetReceiver ||
+        w.androidClassName == oneHourlyWidgetReceiver)) {
+      final id = widgetInfo.androidWidgetId!;
+      for (final prefix in ['hourly6', 'hourly1']) {
+        final key = 'hourlyForecast.${prefix}Names.$id';
+        final stored = await HomeWidget.getWidgetData<String>(key);
+        if (stored == null) continue;
+        final formattedLabels = (jsonDecode(stored) as List).cast<String>()
+            .map((label) => formatHourByTimeMode(DateTime(0, 1, 1, _getHourFromLabel(label)), timeMode))
+            .toList();
+        await saveData(key, jsonEncode(formattedLabels));
+      }
+    }
   }
 
   static Future<void> reloadWidgets() async {


### PR DESCRIPTION
---
  Fix: 1-hour forecast widget not updating when time format setting changed

  What's the problem

  When user switch between 12-hour and 24-hour in settings, the hourly widget just keep showing the old format
  because: no 12 fromat.

  So basically the widget has no idea the user changed anything.

  What I did is add 12 format and when it changed, update corresponding widget, that's it 

#### Closes the following issue(s)
- Closes #214