### PR TITLE
Fix date format setting not persisting across app restarts

### DIFF
--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -309,6 +309,8 @@ class SettingsProvider with ChangeNotifier {
 
     _timeMode = PreferenceUtils.getString("Time mode", "12 hour");
 
+    _dateFormat = PreferenceUtils.getString("Date format", "mm/dd");
+
     _radarHapticsOn = PreferenceUtils.getBool("Radar haptics", true);
 
     _imageSource = PreferenceUtils.getString("Image source", "network");


### PR DESCRIPTION
SettingsProvider._load() reads every persisted setting back into memory on startup (temperature, wind, time mode, etc.) except _dateFormat. setDateFormat() saves correctly via PreferenceUtils.setString("Date format", to), but since _load() never calls the matching getter, _dateFormat always falls back to its field default of "mm/dd" on relaunch. This adds the missing load call, mirroring the pattern used for _timeMode.